### PR TITLE
Added "-bigdcd" flag for pbc wrap

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ CREDITS
 
 The PBCTools plugin has been written by (in alphabetical order)
 * Toni Giorgino <toni.giorgino _at_ isib.cnr.it>
+* Thomas M. Griffiths <tmg994 _at_ uowmail.edu.au>
 * Jerome Henin <jhenin _at_ cmm.upenn.edu>
 * Olaf Lenz <olenz _at_ icp.uni-stuttgart.de> (maintainer)
 * Cameron Mura <cmura _at_ mccammon.ucsd.edu>

--- a/doc/pbctools.tex
+++ b/doc/pbctools.tex
@@ -414,6 +414,10 @@ pbc wrap -cell orthorhombic -shiftcenterrel {1 0 0}
 & Equivalent to \texttt{-first now -last now}.
 \\ \hline
 
+\texttt{-bigdcd}
+& Equivalent to \texttt{-first now -last now}, but without the internal animate command to rewind back to where you stated the wrap. Used when using \texttt{pbc wrap} inside a \texttt{proc} to used with the bigdcd.tcl script for handling large trajectories.
+\\ \hline
+
 \texttt{-cell} \texttt{compact}$|$\texttt{para}[\texttt{llelepiped}]$|$\texttt{brick}$|$\texttt{orthorhombic}$|$\texttt{rectangular}
 & Defines the wrapping type.  Brick is the default, and is the fastest
 method.  Rectangular, brick, and orthorhombic are all synonyms.

--- a/pbcwrap.tcl
+++ b/pbcwrap.tcl
@@ -40,6 +40,7 @@ namespace eval ::PBCTools:: {
 	set molid "top"
 	set first "now"
 	set last "now"
+	set bigdcd 0
 	set wraptype "brick"
 	set sel "all"
 	set compound ""
@@ -61,6 +62,7 @@ namespace eval ::PBCTools:: {
 		"-allframes" -
 		"-all" { set last "last"; set first "first" }
 		"-now" { set last "now"; set first "now" }
+		"-bigdcd" { set last "now"; set first "now"; set bigdcd 1 }
 		"-sel" { set sel $val; incr argnum }
 		"-nocompound" { set compound "" }
 		"-compound" { set compound $val; incr argnum }
@@ -271,9 +273,13 @@ namespace eval ::PBCTools:: {
 	}
 
 	# Rewind to original frame
-	if { $verbose } then { vmdcon -info "Rewinding to frame $frame_before." }
-	animate goto $frame_before
-    }
+	if { $bigdcd } then {
+		if { $verbose } then { vmdcon -info "Using bigdcd, no rewinding done." }
+		} else {
+		if { $verbose } then { vmdcon -info "Rewinding to frame $frame_before." }
+		animate goto $frame_before
+		}
+	}
 
     #########################################################
     # Wrap the selection $wrapsel of molecule $molid


### PR DESCRIPTION
* (pbcwrap) pbcwral.tcl: added "-bigdcd" flag to make the pbc wrap command work when used inside a proc to be used with the bigdcd.tcl script. The flag is equivalent to " now", but bypasses the animate command at the end of pbc wrap.

The animate command at the end of pbc wrap wich is used to rewind to the frame the wrap was started with is conflicting with the animate commands used by bigdcd.tcl to load frames of a dcd one at a time into vmd. The "-bigdcd" flag uses an if statement to bypass the animate command and prints out an info statement if "-verbose" used.

* doc/pbctools.tex: Added description of "-bigdcd" to documentation explaining that it is equivalent to "-now" and intended for use inside a proc that will be called with bigdcd.

* AUTHORS: Added myself to the authors. Remove if contribution not substantial enough to merit addition.