### PR TITLE
ENH: respect resid and resiude as distinct entities

### DIFF
--- a/doc/pbctools.tex
+++ b/doc/pbctools.tex
@@ -82,7 +82,7 @@ printed. The list of available subcommands can be found in table
   
     \texttt{unwrap} [\textit{options}\dots]
     & When overlong bonds (that stretch the whole system) occur and
-    compounds (residues, segments, chains or fragments) are broken in
+    compounds (resids, residues, segments, chains or fragments) are broken in
     the course of a simulation trajectory because atoms are wrapped
     around the periodic boundaries, this function will remove large
     jumps of atoms between consecutive frames.
@@ -431,7 +431,7 @@ this if you don't want to wrap all atoms.
 \texttt{-nocompound}\linebreak $|$\texttt{-compound} \texttt{res}[\texttt{id}[\texttt{ue}]]$|$\texttt{seg}[\texttt{id}]$|$\texttt{chain}$|$\texttt{fragment}
 & Defines, which atom compounds should be kept together, \ie which
 atoms will not be wrapped if a compound would be split by the
-wrapping: residues, segments or chains (default:
+wrapping: resids, residues, segments or chains (default:
 \texttt{-nocompound}).
 Note: this does not presently work with \texttt{-cell compact}.
 \\ \hline
@@ -560,7 +560,7 @@ this if you don't want to unwrap all atoms.
 
 
 \newpage
-\section{\texttt{join} -- Joining residues, chains, segments, fragments,
+\section{\texttt{join} -- Joining resids, residues, chains, segments, fragments,
   and connected/bonded groups}
 \label{sec:join}
 

--- a/pbcjoin.tcl
+++ b/pbcjoin.tcl
@@ -18,7 +18,7 @@ namespace eval ::PBCTools:: {
     #   Joins compounds of type $compound of atoms that have been
     # split due to wrapping around the unit cell boundaries, so that
     # they are not split anymore. $compound must be one of the values
-    # "residue", "chain", "segment", "fragment" or "connected".
+    # "resid", "residue", "chain", "segment", "fragment" or "connected".
     #
     # OPTIONS:
     #   -molid $molid|top
@@ -54,8 +54,11 @@ namespace eval ::PBCTools:: {
                 set compoundtype "segid"
                 set compoundseltext "segid %s"
             }
+            "resid" {
+                set compoundtype "resid"
+                set compoundseltext "resid %s"
+            }
             "res" -
-            "resid" -
             "residue" {
                 set compoundtype "residue"
                 set compoundseltext "residue %s"
@@ -76,7 +79,7 @@ namespace eval ::PBCTools:: {
             default {
                 vmdcon -err "pbcjoin: unknown compound type $compoundtype"
                 vmdcon -err "pbcjoin: syntax: pbc join <compound> \[<options> ...\]"
-                vmdcon -err "pbcjoin: supported compound types: segment, residue, chain, fragment, connected"
+                vmdcon -err "pbcjoin: supported compound types: segment, resid, residue, chain, fragment, connected"
                 error "pbcjoin: argument parse error"
             }
         }
@@ -165,6 +168,11 @@ namespace eval ::PBCTools:: {
                 "segid" {
                     foreach segid [lsort -unique [$sel get segid]] {
                         lappend compoundlist "segid $segid"
+                    }
+                }
+                "resid" {
+                    foreach resid [lsort -integer -unique [$sel get resid]] {
+                        lappend compoundlist "resid $resid"
                     }
                 }
                 "residue" {

--- a/pbcwrap.tcl
+++ b/pbcwrap.tcl
@@ -96,8 +96,8 @@ namespace eval ::PBCTools:: {
 	# handle compounds
 	switch -- $compound {
 	    "" {}
+	    "resid" { set compound "resid" }
 	    "res" -
-	    "resid" -
 	    "residue" { set compound "residue" }
 	    "seg" -
 	    "segid" { set compound "segid" }
@@ -307,7 +307,7 @@ namespace eval ::PBCTools:: {
     # Wrap all atoms in $wrapsel to their closest approach
     # to the origin.  This ignores molecule selections
     # because there doesn't seem to be a way to loop
-    # over residues / chains / etc. inside the selection.
+    # over resid / residues / chains / etc. inside the selection.
     #
     # TODO:
     # Maybe there's a way to select the first atom of each residue,


### PR DESCRIPTION
`resid` and `residue` are different concepts in VMD, thus allow to join and wrap by both.