### PR TITLE
Allow folks to use the von Bulow unwrapping scheme

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ The PBCTools plugin has been written by (in alphabetical order)
 * Cameron Mura <cmura _at_ mccammon.ucsd.edu>
 * David M. Rogers <davidrogers _at_ predictivestatmech.org>
 * Jan Saam <saam _at_ charite.de>
+* Josh Vermaas <joshua.vermaas _at_ gmail.com>
 
 The "pbcbox" procedure copies a lot of the ideas of Axel Kohlmeyer's
 script "vmd_draw_unitcell".  David Rogers added shortest vector

--- a/doc/pbctools.tex
+++ b/doc/pbctools.tex
@@ -24,7 +24,7 @@
 \begin{document}
 \title{\pbctools Plugin User's Guide}
 \author{Jerome Henin \and Olaf Lenz \and Cameron Mura \and David M. Rogers \and Jan Saam}
-\date{Version 3.0}
+\date{Version 3.1}
 
 \maketitle
 
@@ -555,6 +555,22 @@ this if you don't want to unwrap all atoms.
 \texttt{-}[\texttt{no}]\texttt{verbose}
 & Turn on/off verbosity of the function (for debugging) (default:
 \texttt{-noverbose}).
+\\ \hline
+
+\texttt{-}[\texttt{no}]\texttt{heuristic}
+& Change between the heuristic and displacement methods for unwrapping
+NpT simulations. \texttt{-noheuristic} switches to the displacement
+method from \href{https://aip.scitation.org/doi/full/10.1063/5.0008316}{von B\"ulow et al},
+while the default \texttt{-heuristic} algorithm is what MD engines use.
+For most applications, \texttt{-heuristic} should be preferred.
+\\ \hline
+
+\texttt{-}[\texttt{no}]\texttt{displacement}
+& Change between the heuristic and displacement methods for unwrapping
+NpT simulations. \texttt{-displacement} switches to the displacement
+method from \href{https://aip.scitation.org/doi/full/10.1063/5.0008316}{von B\"ulow et al},
+while the default algorithm is what MD engines use. This is the converse
+of the \texttt{-heuristic}, and so \texttt{-nodisplacement} is the default.
 \\ \hline
 \end{tabular}
 

--- a/pbcbox.tcl
+++ b/pbcbox.tcl
@@ -11,7 +11,7 @@
 # $Id: pbcbox.tcl,v 1.16 2013/04/15 14:36:25 johns Exp $
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*

--- a/pbcjoin.tcl
+++ b/pbcjoin.tcl
@@ -6,7 +6,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 package require struct::queue
 
 namespace eval ::PBCTools:: {

--- a/pbcset.tcl
+++ b/pbcset.tcl
@@ -6,7 +6,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*

--- a/pbctools.tcl
+++ b/pbctools.tcl
@@ -15,7 +15,7 @@
 ##
 ## $Id$
 ##
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 ###################################################
 # Main namespace procedures

--- a/pbcunwrap.tcl
+++ b/pbcunwrap.tcl
@@ -36,7 +36,7 @@ namespace eval ::PBCTools:: {
 	set last "last"
 	set seltext "all"
 	set verbose 0
-	set heuristic 0
+	set heuristic 1
 	
 	# Parse options
 	for { set argnum 0 } { $argnum < [llength $args] } { incr argnum } {

--- a/pbcwrap.tcl
+++ b/pbcwrap.tcl
@@ -8,7 +8,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*


### PR DESCRIPTION
This implements the changes needed to implement the unwrapping scheme outlined in https://aip.scitation.org/doi/full/10.1063/5.0008316. I've thoroughly evaluated the scheme, and while it might have applications in some corner cases, it should not be the default, since the transformation cannot be easily reversed (it is not the inverse of the wrap transformation).