### PR TITLE
Correcting the unwrapping algorithm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ The PBCTools plugin has been written by (in alphabetical order)
 * Toni Giorgino <toni.giorgino _at_ isib.cnr.it>
 * Jerome Henin <jhenin _at_ cmm.upenn.edu>
 * Johannes Hoermann <johannes.hoermann _at_ imtek.uni-freiburg.de>
+* Martin Kulke <kulkemar _at_ msu.edu>
 * Olaf Lenz <olenz _at_ icp.uni-stuttgart.de> (maintainer)
 * Cameron Mura <cmura _at_ mccammon.ucsd.edu>
 * David M. Rogers <davidrogers _at_ predictivestatmech.org>

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CXXFLAGS += -g
 VMFILES = pbcbox.tcl pbcgui.tcl pbcjoin.tcl pbcset.tcl pbctools.tcl \
 	pbcunwrap.tcl pbcwrap.tcl pkgIndex.tcl
 
-VMVERSION = 3.0
+VMVERSION = 3.1
 ARCHDIR=${COMPILEDIR}/lib_${ARCH}/tcl/pbctools$(VMVERSION)
 
 VPATH = src ${ARCHDIR}

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,8 @@
-Changes in v3.0a1
+Changes in v3.1
 ---------------
 
 * Changed the unwrapping scheme to the corrected displacement scheme from
-  kulke & Vermaas. The previous unwrapping method calculated wrong results
+  Kulke & Vermaas. The previous unwrapping method calculated wrong results
   at very large simulation time lengths (atoms move >18 periodic boxes).
 * added -heuristic and -displacement flag to pbc unwrap. The displacement method
   is the standard method used, if both flags are not specified.

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+Changes in v3.0a1
+---------------
+
+* Changed the unwrapping scheme to the corrected displacement scheme from
+  kulke & Vermaas. The previous unwrapping method calculated wrong results
+  at very large simulation time lengths (atoms move >18 periodic boxes).
+* added -heuristic and -displacement flag to pbc unwrap. The displacement method
+  is the standard method used, if both flags are not specified.
+
 Changes in v3.0
 ---------------
 

--- a/pbcbox.tcl
+++ b/pbcbox.tcl
@@ -11,7 +11,7 @@
 # $Id: pbcbox.tcl,v 1.16 2013/04/15 14:36:25 johns Exp $
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*

--- a/pbcgui.tcl
+++ b/pbcgui.tcl
@@ -8,8 +8,8 @@
 # $Id: pbcgui.tcl,v 1.4 2013/04/15 16:48:10 johns Exp $
 #
 # create package and namespace and default all namespace global variables.
-package provide pbcgui 3.0
-package require pbctools 3.0
+package provide pbcgui 3.1
+package require pbctools 3.1
 
 namespace eval ::pbcgui:: {
     namespace export pbcgui

--- a/pbcjoin.tcl
+++ b/pbcjoin.tcl
@@ -6,7 +6,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 package require struct::queue
 
 namespace eval ::PBCTools:: {

--- a/pbcset.tcl
+++ b/pbcset.tcl
@@ -6,7 +6,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*

--- a/pbctools.tcl
+++ b/pbctools.tcl
@@ -15,7 +15,7 @@
 ##
 ## $Id$
 ##
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 ###################################################
 # Main namespace procedures

--- a/pbcunwrap.tcl
+++ b/pbcunwrap.tcl
@@ -24,8 +24,10 @@ namespace eval ::PBCTools:: {
     #   -all|allframes
     #   -sel $sel
     #   -[no]verbose
+    #   -[no]heuristic
+    #   -[no]displacement
     #
-    # AUTHORS: Olaf, Jerome, Cameron
+    # AUTHORS: Martin, Olaf, Jerome, Cameron
     #
     proc pbcunwrap {args} {
 	# Set the defaults
@@ -34,6 +36,7 @@ namespace eval ::PBCTools:: {
 	set last "last"
 	set seltext "all"
 	set verbose 0
+	set heuristic 0
 	
 	# Parse options
 	for { set argnum 0 } { $argnum < [llength $args] } { incr argnum } {
@@ -49,6 +52,10 @@ namespace eval ::PBCTools:: {
 		"-sel" { set seltext $val; incr argnum }
 		"-verbose" { set verbose 1 }
 		"-noverbose" { incr verbose 0 }
+		"-noheuristic" { set heuristic 0 }
+		"-heuristic" { incr heuristic } 
+		"-displacement" { set heuristic 0 }
+		"-nodisplacement" { incr heuristic }
 		default { error "pbcunwrap: unknown option: $arg" }
 	    }
 	}
@@ -80,7 +87,14 @@ namespace eval ::PBCTools:: {
 	set oldxs [$sel get x]
 	set oldys [$sel get y]
 	set oldzs [$sel get z]
-
+	
+	if { $heuristic == 0 } {
+		set unwrapx $oldxs
+		set unwrapy $oldys
+		set unwrapz $oldzs
+        set oldcell [lindex [pbcget -check -molid $molid -namd] 0]
+	}
+	
 	set next_time [clock clicks -milliseconds]
 	set show_step 1000
 	set fac [expr 100.0/($last - $first + 1)]
@@ -105,18 +119,47 @@ namespace eval ::PBCTools:: {
 	    set ys [$sel get y]
 	    set zs [$sel get z]
 
-	    # wrap the coordinates
-	    pbcwrap_coordinates $A $B $C xs ys zs $oldxs $oldys $oldzs
-	    
-	    # set the new coordinates
-	    $sel set x $xs
-	    $sel set y $ys 
-	    $sel set z $zs
+	    if { $heuristic > 0 } {
+	    	# wrap the coordinates
+		    pbcwrap_coordinates $A $B $C xs ys zs $oldxs $oldys $oldzs
+		    
+		    # set the new coordinates
+		    $sel set x $xs
+		    $sel set y $ys 
+		    $sel set z $zs
+
+		#This calculates unwrapping based on displacement
+	    } else {
+		    set vx [vecsub $xs $oldxs]
+		    set vy [vecsub $ys $oldys]
+		    set vz [vecsub $zs $oldzs]
+		    
+		    set vx2 [vecsub $oldxs $unwrapx]
+		    set vy2 [vecsub $oldys $unwrapy]
+		    set vz2 [vecsub $oldzs $unwrapz]
+
+		    # unwrap the displacements
+		    for {set c 0} {$c < [llength $vx]} {incr c} {
+                lset vx $c [expr [lindex $vx $c]-floor([lindex $vx $c]/[lindex $cell 0 0]+0.5)*[lindex $cell 0 0]-floor(([lindex $vx2 $c])/[lindex $oldcell 0 0]+0.5)*([lindex $cell 0 0]-[lindex $oldcell 0 0])]
+                lset vy $c [expr [lindex $vy $c]-floor([lindex $vy $c]/[lindex $cell 1 1]+0.5)*[lindex $cell 1 1]-floor(([lindex $vy2 $c])/[lindex $oldcell 1 1]+0.5)*([lindex $cell 1 1]-[lindex $oldcell 1 1])]
+                lset vz $c [expr [lindex $vz $c]-floor([lindex $vz $c]/[lindex $cell 2 2]+0.5)*[lindex $cell 2 2]-floor(([lindex $vz2 $c])/[lindex $oldcell 2 2]+0.5)*([lindex $cell 2 2]-[lindex $oldcell 2 2])]}
+
+		    # add displacements to previous unwrapped coordinates
+		    set unwrapx [vecadd $vx $unwrapx]
+			set unwrapy [vecadd $vy $unwrapy]
+			set unwrapz [vecadd $vz $unwrapz]
+		    
+		    # set the new coordinates
+		    $sel set x $unwrapx
+		    $sel set y $unwrapy
+		    $sel set z $unwrapz
+	    }
 
 	    # save the coordinates
-	    set oldxs $xs
-	    set oldys $ys
-	    set oldzs $zs
+		set oldxs $xs
+		set oldys $ys
+		set oldzs $zs
+		if { $heuristic == 0 } {set oldcell $cell}
 
 	    set time [clock clicks -milliseconds]
 	    if {$verbose || $frame == $last || $time >= $next_time} then {

--- a/pbcunwrap.tcl
+++ b/pbcunwrap.tcl
@@ -8,7 +8,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*

--- a/pbcwrap.tcl
+++ b/pbcwrap.tcl
@@ -8,7 +8,7 @@
 # $Id$
 #
 
-package provide pbctools 3.0
+package provide pbctools 3.1
 
 namespace eval ::PBCTools:: {
     namespace export pbc*

--- a/pkgIndex.tcl
+++ b/pkgIndex.tcl
@@ -8,6 +8,6 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded pbcgui 3.0 [list source [file join $dir pbcgui.tcl]]
-package ifneeded pbctools 3.0 [list source [file join $dir pbcbox.tcl]]\n[list source [file join $dir pbcjoin.tcl]]\n[list source [file join $dir pbcset.tcl]]\n[list source [file join $dir pbctools.tcl]]\n[list source [file join $dir pbcunwrap.tcl]]\n[list source [file join $dir pbcwrap.tcl]]
-package ifneeded pbc_core 3.0 [load [file join $dir libpbc_core.so]]
+package ifneeded pbcgui 3.1 [list source [file join $dir pbcgui.tcl]]
+package ifneeded pbctools 3.1 [list source [file join $dir pbcbox.tcl]]\n[list source [file join $dir pbcjoin.tcl]]\n[list source [file join $dir pbcset.tcl]]\n[list source [file join $dir pbctools.tcl]]\n[list source [file join $dir pbcunwrap.tcl]]\n[list source [file join $dir pbcwrap.tcl]]
+package ifneeded pbc_core 3.1 [load [file join $dir libpbc_core.so]]


### PR DESCRIPTION
The heuristic unwrapping method leads to unwrapping errors in long NPT trajectories, where atoms traversed multiple periodic boxes. We developed and implemented a new unwrapping algorithm based on the displacement method "https://doi.org/10.48550/arXiv.2111.12052" that corrects this. The current implementation does not utilize the c-library and works only for orthorhombic boxes.